### PR TITLE
Serve font awesome as part of the frontend

### DIFF
--- a/ipywidgets_server/app.py
+++ b/ipywidgets_server/app.py
@@ -141,7 +141,7 @@ class WidgetsServer(Application):
         )
         handlers = [
             (
-                r'/api/kernels', 
+                r'/api/kernels',
                 CustomKernelHandler,
                 {
                     'module_name': self.module_name,
@@ -152,7 +152,7 @@ class WidgetsServer(Application):
             (r'/api/kernels/%s/channels' % _kernel_id_regex, ZMQChannelsHandler),
             (r'/api/kernelspecs', MainKernelSpecHandler),
             (
-                r"/(.*)", 
+                r"/(.*)",
                 tornado.web.StaticFileHandler,
                 {
                     'path': STATIC_ROOT,
@@ -171,7 +171,6 @@ class WidgetsServer(Application):
             tornado.ioloop.IOLoop.current().start()
         finally:
             shutil.rmtree(connection_dir)
-
 
 
 main = WidgetsServer.launch_instance

--- a/js/embed.js
+++ b/js/embed.js
@@ -6,6 +6,7 @@ import { RenderMime, defaultRendererFactories } from '@jupyterlab/rendermime';
 
 import { WidgetManager } from './manager'
 
+import 'font-awesome/css/font-awesome.css'
 import './widgets.css'
 
 export async function renderWidgets(baseUrl, wsUrl, loader) {

--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,8 @@
     "@jupyterlab/outputarea": "^0.10.0",
     "@jupyterlab/rendermime": "^0.10.0",
     "@jupyterlab/services": "^0.49.0",
-    "@phosphor/widgets": "^1.5.0"
+    "@phosphor/widgets": "^1.5.0",
+    "font-awesome": "^4.7.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -18,11 +19,13 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "css-loader": "^0.28.7",
+    "file-loader": "^1.1.5",
     "postcss": "^6.0.11",
     "postcss-cssnext": "^3.0.2",
     "postcss-import": "^10.0.0",
     "postcss-loader": "^2.0.6",
     "style-loader": "^0.18.2",
+    "url-loader": "^0.6.2",
     "webpack": "^3.6.0"
   },
   "scripts": {

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = [
         output: {
             filename: 'libwidgets.js',
             path: distRoot,
-            libraryTarget: 'amd'
+            libraryTarget: 'amd',
+            publicPath: '/dist/'
         },
         module: { loaders: loaders },
         devtool: 'source-map'


### PR DESCRIPTION
This PR addresses issue #6 . 

This should make the ipywidgets_server more similar to the frontend served by the html manager.