### PR TITLE
Avoid truncating tall widgets

### DIFF
--- a/ipywidgets_server/static/index.html
+++ b/ipywidgets_server/static/index.html
@@ -15,28 +15,25 @@
         />
         <style>
             html, body {
-                height: 100%;
+                height: 100vh;
             }
 
-            .fill {
-                min-height: 100%;
-                height: 100%;
+            .ipywidgets-server-contents-container {
+                height: 95vh;
+                padding-top: 5vh;
+            }
+
+            #result {
+                margin-top: auto;
+                margin-bottom: auto;
             }
         </style>
     </head>
 
     <body>
-        <div class="container fill">
-            <div class="row">
-                <div class="col">
-                    <div id="errors"></div>
-                </div>
-            </div>
-            <div class="row align-items-center fill">
-                <div class="col">
-                    <div id="result"></div>
-                </div>
-            </div>
+        <div class="container fill d-flex flex-column align-items-stretch ipywidgets-server-contents-container">
+            <div id="errors"></div>
+            <div id="result"></div>
         </div>
     </body>
 </html>

--- a/ipywidgets_server/static/index.html
+++ b/ipywidgets_server/static/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script 
+        <script
             data-main="/main"
-            src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js" 
-            integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA=" 
+            src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"
+            integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
             crossorigin="anonymous">
         </script>
-        <link 
+        <link
             rel="stylesheet"
             href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"
             integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ"


### PR DESCRIPTION
Prior to this PR, tall widgets were truncated. The widgets were set to be centered on the page, which meant that widgets that were taller than the page overflowed vertically above the screen.

Widgets are now set to align with the start of the flexbox. We still center short widgets vertically by setting auto margins.

This addresses issue #9 .