### PR TITLE
Change default port to 8866

### DIFF
--- a/ipywidgets_server/app.py
+++ b/ipywidgets_server/app.py
@@ -104,9 +104,9 @@ class WidgetsServer(Application):
     module_name = Unicode()
     object_name = Unicode()
     port = Integer(
-        8888,
+        8866,
         config=True,
-        help='Port of the ipywidgets server. Default 8888.'
+        help='Port of the ipywidgets server. Default 8866.'
     )
     static_root = Unicode(
         str(DEFAULT_STATIC_ROOT),


### PR DESCRIPTION
The default port is currently 8888. In hindsight, I think this was a poor choice -- users will often already have a notebook running, probably on port 8888.

This changes the port to 8866. 

Note that you can always pass a custom port with the `--port 4334` argument.