### PR TITLE
Log error messages in callbacks

### DIFF
--- a/ipywidgets_server/app.py
+++ b/ipywidgets_server/app.py
@@ -104,9 +104,9 @@ class WidgetsServer(Application):
     module_name = Unicode()
     object_name = Unicode()
     port = Integer(
-        8888,
+        8866,
         config=True,
-        help='Port of the ipywidgets server. Default 8888.'
+        help='Port of the ipywidgets server. Default 8866.'
     )
     static_root = Unicode(
         str(DEFAULT_STATIC_ROOT),

--- a/ipywidgets_server/static/index.html
+++ b/ipywidgets_server/static/index.html
@@ -32,8 +32,8 @@
 
     <body>
         <div class="container fill d-flex flex-column align-items-stretch ipywidgets-server-contents-container">
-            <div id="ipywidget-server-errors"></div>
             <div id="ipywidget-server-result"></div>
+            <div id="ipywidget-server-errors"></div>
         </div>
     </body>
 </html>

--- a/js/ErrorView.js
+++ b/js/ErrorView.js
@@ -1,0 +1,21 @@
+
+import { OutputAreaModel, OutputArea } from '@jupyterlab/outputarea';
+import { renderMime } from './renderMime'
+
+// Output view for errors in callbacks
+export class ErrorView {
+    constructor(element) {
+        this._element = element
+        this._outputModel = new OutputAreaModel({trusted: true})
+        this._outputView = new OutputArea({
+            rendermime: renderMime,
+            model: this._outputModel,
+        })
+        this._element.appendChild(this._outputView.node)
+    }
+
+    showError(errorContent) {
+        const model = { ...errorContent, output_type: 'error' }
+        this._outputModel.add(model)
+    }
+}

--- a/js/embed.js
+++ b/js/embed.js
@@ -1,10 +1,8 @@
 
 import { Kernel, ServerConnection, KernelMessage } from '@jupyterlab/services'
 
-import { OutputAreaModel, OutputArea } from '@jupyterlab/outputarea';
-
 import { WidgetManager } from './manager'
-import { renderMime } from './renderMime'
+import { ErrorView } from './ErrorView'
 
 import 'font-awesome/css/font-awesome.css'
 import './widgets.css'
@@ -25,14 +23,10 @@ export async function renderWidgets(baseUrl, wsUrl, loader) {
     });
 
     const el = document.getElementById('ipywidget-server-result')
-    const errorEl = document.getElementById('ipywidget-server-errors')
     const manager = new WidgetManager(kernel, el, loader);
-    const outputModel = new OutputAreaModel({trusted: true});
-    const outputView = new OutputArea({
-        rendermime: renderMime,
-        model: outputModel,
-    })
-    errorEl.appendChild(outputView.node)
+
+    const errorEl = document.getElementById('ipywidget-server-errors')
+    const errorView = new ErrorView(errorEl);
 
     const options = {
         msgType: 'custom_message',
@@ -55,9 +49,7 @@ export async function renderWidgets(baseUrl, wsUrl, loader) {
         }
         else if (KernelMessage.isErrorMsg(msg)) {
             // Show errors to help with debugging
-            const model = msg.content
-            model.output_type = 'error'
-            outputModel.add(model)
+            errorView.showError(msg.content)
         }
     }
 }

--- a/js/embed.js
+++ b/js/embed.js
@@ -27,6 +27,7 @@ export async function renderWidgets(baseUrl, wsUrl, loader) {
 
     const errorEl = document.getElementById('ipywidget-server-errors')
     const errorView = new ErrorView(errorEl);
+    manager.onError.connect((sender, msg) => errorView.showError(msg.content))
 
     const options = {
         msgType: 'custom_message',

--- a/js/manager.js
+++ b/js/manager.js
@@ -2,6 +2,7 @@
 import * as base from '@jupyter-widgets/base'
 import * as controls from '@jupyter-widgets/controls';
 import * as pWidget from '@phosphor/widgets';
+import { Signal } from '@phosphor/signaling';
 
 import { HTMLManager } from '@jupyter-widgets/html-manager';
 
@@ -15,6 +16,11 @@ export class WidgetManager extends HTMLManager {
         this.registerWithKernel(kernel)
         this.el = el;
         this.loader = loader;
+        this._onError = new Signal(this)
+    }
+
+    get onError() {
+        return this._onError
     }
 
     registerWithKernel(kernel) {
@@ -58,7 +64,7 @@ export class WidgetManager extends HTMLManager {
         const baseCallbacks = super.callbacks(view)
         return {
             ...baseCallbacks,
-            iopub: { output: (msg) => console.log(msg) }
+            iopub: { output: (msg) => this._onError.emit(msg) }
         }
     }
 

--- a/js/package.json
+++ b/js/package.json
@@ -11,6 +11,7 @@
     "@jupyterlab/outputarea": "^0.10.0",
     "@jupyterlab/rendermime": "^0.10.0",
     "@jupyterlab/services": "^0.49.0",
+    "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.5.0",
     "font-awesome": "^4.7.0"
   },

--- a/js/services-shim.js
+++ b/js/services-shim.js
@@ -1,0 +1,104 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Copied from https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/base/src/services-shim.ts
+
+/**
+ * This module defines shims for @jupyterlab/services that allows you to use the
+ * old comm API.  Use this, @jupyterlab/services, and the widget base manager to
+ * embed live widgets in a context outside of the notebook.
+ */
+
+// Modified this slightly to also intercept error messages from the
+// kernel so they can be displayed in the error area.
+
+import { Kernel } from '@jupyterlab/services';
+
+
+export class ShimmedComm  {
+    constructor(jsServicesComm) {
+        this.jsServicesComm = jsServicesComm;
+        this.comm_id = this.jsServicesComm.commId
+        this.target_name = this.jsServicesComm.targetName
+    }
+
+
+    /**
+    * Opens a sibling comm in the backend
+    */
+    open(data, callbacks, metadata, buffers) {
+        const future = this.jsServicesComm.open(data, metadata, buffers);
+        this._hookupCallbacks(future, callbacks);
+        return future.msg.header.msg_id;
+    }
+
+    /**
+    * Sends a message to the sibling comm in the backend
+    */
+    send(data, callbacks, metadata, buffers) {
+        let future = this.jsServicesComm.send(data, metadata, buffers);
+        this._hookupCallbacks(future, callbacks);
+        return future.msg.header.msg_id;
+    }
+
+    /**
+    * Closes the sibling comm in the backend
+    */
+    close(data, callbacks, metadata, buffers) {
+        let future = this.jsServicesComm.close(data, metadata, buffers);
+        this._hookupCallbacks(future, callbacks);
+        return future.msg.header.msg_id;
+    }
+
+    /**
+    * Register a message handler
+    */
+    on_msg(callback) {
+        this.jsServicesComm.onMsg = callback.bind(this);
+    }
+
+    /**
+    * Register a handler for when the comm is closed by the backend
+    */
+    on_close(callback) {
+        this.jsServicesComm.onClose = callback.bind(this);
+    }
+
+    /**
+    * Hooks callback object up with @jupyterlab/services IKernelFuture
+    */
+    _hookupCallbacks(future, callbacks) {
+        if (callbacks) {
+            future.onReply = function(msg) {
+                if (callbacks.shell && callbacks.shell.reply) {
+                    callbacks.shell.reply(msg);
+                }
+                // TODO: Handle payloads.  See https://github.com/jupyter/notebook/blob/master/notebook/static/services/kernels/kernel.js#L923-L947
+            };
+
+            future.onStdin = function(msg) {
+                if (callbacks.input) {
+                    callbacks.input(msg);
+                }
+            };
+
+            future.onIOPub = function(msg) {
+                if (callbacks.iopub) {
+                    if (callbacks.iopub.status && msg.header.msg_type === 'status') {
+                        callbacks.iopub.status(msg);
+                    } else if (callbacks.iopub.clear_output && msg.header.msg_type === 'clear_output') {
+                        callbacks.iopub.clear_output(msg);
+                    } else if (callbacks.iopub.output) {
+                        switch (msg.header.msg_type) {
+                            case 'display_data':
+                            case 'execute_result':
+                            case 'error':
+                                callbacks.iopub.output(msg);
+                                break;
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -52,9 +52,9 @@ module.exports = [
         output: {
             filename : 'base.js',
             path: path.resolve(distRoot, '@jupyter-widgets'),
-            libraryTarget: 'amd',
+            libraryTarget: 'amd'
         },
-        module: { loaders: loaders },
+        module: { loaders: loaders }
     },
     {// @jupyter-widgets/controls
         entry: '@jupyter-widgets/controls/lib/index',


### PR DESCRIPTION
Prior to this PR, messages raised in widget callbacks were swallowed. For instance, the following would show nothing when the user clicked the button:

```py
widget = widgets.Button()

def cb(arg):
    raise Exception('bla bla bla')

widget.on_click(cb)
```

This makes debugging much harder. The only way to see the exception is to view the websocket frames -- probably not something most users of ipywidget servers will be familiar with. Note that widget in jupyter lab suffer from the same problem, with the additional complication that it isn't obvious where errors should go.

This PR catches error messages from the comms and displays them in the error area.