### PR TITLE
Better error handling in stock price example

### DIFF
--- a/examples/stock_price/example.py
+++ b/examples/stock_price/example.py
@@ -25,8 +25,10 @@ def get_stock_price(symbol):
 def handle_fetch_error(error, symbol):
     if error.code == 404:
         message = 'Stock symbol {} not found'.format(symbol)
+    elif error.code == 429:
+        message = 'Too many requests to the API. Try again later.'
     else:
-        message = 'Unexpected error'
+        message = 'Unexpected error status: {}'.format(error.code)
     result_container.children = [widgets.Label(message)]
 
 


### PR DESCRIPTION
The Quandl API sometimes replies with 429. We now handle that explicitly.