### PR TITLE
Do not bundle base and control

### DIFF
--- a/ipywidgets_server/static/main.js
+++ b/ipywidgets_server/static/main.js
@@ -6,6 +6,17 @@ requirejs.config({
     baseUrl: 'dist'
 })
 
+// Export jupyter-widgets base and controls packages to make them
+// available to community widget libraries that have these normally
+// defined as external.
+define('@jupyter-widgets/base', ['libwidgets'], function(lib) {
+  return lib.base;
+})
+
+define('@jupyter-widgets/controls', ['libwidgets'], function(lib) {
+  return lib.controls;
+})
+
 require(['libwidgets'], function(lib) {
     var BASEURL = window.location.href
 

--- a/ipywidgets_server/static/main.js
+++ b/ipywidgets_server/static/main.js
@@ -10,11 +10,11 @@ requirejs.config({
 // available to community widget libraries that have these normally
 // defined as external.
 define('@jupyter-widgets/base', ['libwidgets'], function(lib) {
-  return lib.base;
+    return lib.base;
 })
 
 define('@jupyter-widgets/controls', ['libwidgets'], function(lib) {
-  return lib.controls;
+    return lib.controls;
 })
 
 require(['libwidgets'], function(lib) {

--- a/js/index.js
+++ b/js/index.js
@@ -1,2 +1,10 @@
 export { WidgetApplication } from './WidgetApplication';
 export * from './loader';
+
+// Re-export '@jupyter-widgets/controls' and '@jupyter-widgets/base'
+// to make them available to client libraries.
+
+export * as base from '@jupyter-widgets/base'
+export * as controls from '@jupyter-widgets/controls'
+
+

--- a/js/index.js
+++ b/js/index.js
@@ -6,5 +6,3 @@ export * from './loader';
 
 export * as base from '@jupyter-widgets/base'
 export * as controls from '@jupyter-widgets/controls'
-
-

--- a/js/manager.js
+++ b/js/manager.js
@@ -9,11 +9,6 @@ import * as outputWidgets from './output';
 import { ShimmedComm } from './services-shim';
 import { createRenderMimeRegistryWithWidgets } from './renderMime';
 
-if (typeof window !== "undefined" && typeof window.define !== "undefined") {
-  window.define("@jupyter-widgets/base", base);
-  window.define("@jupyter-widgets/controls", controls);
-}
-
 export class WidgetManager extends HTMLManager {
     constructor(kernel, el, loader) {
         super();

--- a/js/manager.js
+++ b/js/manager.js
@@ -1,4 +1,3 @@
-
 import * as base from '@jupyter-widgets/base'
 import * as controls from '@jupyter-widgets/controls';
 import * as pWidget from '@phosphor/widgets';
@@ -9,6 +8,11 @@ import { HTMLManager } from '@jupyter-widgets/html-manager';
 import * as outputWidgets from './output';
 import { ShimmedComm } from './services-shim';
 import { createRenderMimeRegistryWithWidgets } from './renderMime';
+
+if (typeof window !== "undefined" && typeof window.define !== "undefined") {
+  window.define("@jupyter-widgets/base", base);
+  window.define("@jupyter-widgets/controls", controls);
+}
 
 export class WidgetManager extends HTMLManager {
     constructor(kernel, el, loader) {

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -44,26 +44,5 @@ module.exports = [
         },
         module: { loaders: loaders },
         devtool: 'source-map'
-    },
-
-    // Exports needed for custom widget libraries.
-    {// @jupyter-widgets/base
-        entry: '@jupyter-widgets/base/lib/index',
-        output: {
-            filename : 'base.js',
-            path: path.resolve(distRoot, '@jupyter-widgets'),
-            libraryTarget: 'amd'
-        },
-        module: { loaders: loaders }
-    },
-    {// @jupyter-widgets/controls
-        entry: '@jupyter-widgets/controls/lib/index',
-        output: {
-            filename : 'controls.js',
-            path: path.resolve(distRoot, '@jupyter-widgets'),
-            libraryTarget: 'amd'
-        },
-        module: { loaders: loaders },
-        externals: ['@jupyter-widgets/base']
     }
 ]

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,7 @@ class NPM(Command):
 
     lib_root = os.path.join(here, 'ipywidgets_server', 'static', 'dist')
     targets = [
-        os.path.join(lib_root, 'libwidgets.js'),
-        os.path.join(lib_root, '@jupyter-widgets', 'base.js'),
-        os.path.join(lib_root, '@jupyter-widgets', 'controls.js')
+        os.path.join(lib_root, 'libwidgets.js')
     ]
 
     def initialize_options(self):
@@ -155,7 +153,6 @@ setup_args = {
         'ipywidgets_server': [
             'static/*',
             'static/dist/*',
-            'static/dist/@jupyter-widgets/*',
             'kernel.json'
         ]
     },


### PR DESCRIPTION
This was a bug because base and control were both in the main bundle (since not declared as externals) and in their own bundles.

This makes setting the base url unnecessary. cc @pbugnion 